### PR TITLE
debug/pu chat

### DIFF
--- a/apps/chat/tests.py
+++ b/apps/chat/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/apps/chat/tests/factories.py
+++ b/apps/chat/tests/factories.py
@@ -1,0 +1,72 @@
+import factory
+from django.contrib.auth import get_user_model
+from apps.chat.models import Chat, Mensaje
+from apps.ecas.models import PuntoECA
+from config import constants as cons
+
+class UsuarioFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+
+    email = factory.Sequence(lambda n: f"user{n}@example.com")
+    nombres = factory.Faker("first_name")
+    apellidos = factory.Faker("last_name")
+    tipo_documento = "CC"
+    numero_documento = factory.Sequence(lambda n: f"123456{n}")
+    fecha_nacimiento = "1990-01-01"
+    tipo_usuario = cons.TipoUsuario.CIUDADANO
+    is_active = True
+    celular = factory.Sequence(lambda n: f"3{(n % 1000000000):09d}")  # Colombian mobile format
+    password = factory.PostGenerationMethodCall('set_password', 'defaultpassword')
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        """Create user with proper password handling"""
+        password = kwargs.pop('password', None)
+        # Create the user instance
+        instance = model_class(*args, **kwargs)
+        if password is not None:
+            instance.set_password(password)
+        else:
+            instance.set_password('defaultpassword')
+        instance.save()
+        return instance
+
+    @classmethod
+    def gestor(cls):
+        """Create a usuario gestor ECA"""
+        return cls(tipo_usuario=cons.TipoUsuario.GESTOR_ECA)
+
+class PuntoECAFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PuntoECA
+
+    nombre = factory.Sequence(lambda n: f"Punto ECA-{n}")
+    email = factory.Sequence(lambda n: f"puntoeca{n}@example.com")
+    telefono_punto = factory.Sequence(lambda n: f"6012345{(n % 1000):03d}")  # Format: 60 + 7 digits
+    celular = factory.Sequence(lambda n: f"3{(n % 1000000000):09d}")  # Format: 3 + 9 digits
+
+class ChatFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Chat
+
+    punto = factory.SubFactory(PuntoECAFactory)
+    ciudadano = factory.SubFactory(UsuarioFactory)
+    created_at = factory.Faker("date_time_this_year")
+
+    @classmethod
+    def con_gestor(cls):
+        """Create a chat with a gestor ECA instead of a ciudadano"""
+        return cls(ciudadano=UsuarioFactory.gestor())
+
+class MensajeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Mensaje
+
+    chat = factory.SubFactory(ChatFactory)
+    remitente = factory.SubFactory(UsuarioFactory)
+    texto = factory.Faker("sentence")
+    enviado_en = factory.Faker("date_time_this_year")
+    leido = False
+    editado = False
+

--- a/apps/chat/tests/test_models.py
+++ b/apps/chat/tests/test_models.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from apps.chat.models import Chat, Mensaje
+from apps.chat.tests.factories import ChatFactory, MensajeFactory, UsuarioFactory
+
+class ChatModelTestCase(TestCase):
+    def test_unique_constraint_chat(self):
+        chat1 = ChatFactory()
+        with self.assertRaises(Exception):
+            ChatFactory(punto=chat1.punto, ciudadano=chat1.ciudadano)
+
+    def test_chat_creation(self):
+        chat = ChatFactory()
+        self.assertIsInstance(chat, Chat)
+        self.assertIsNotNone(chat.created_at)
+        
+    def test_chat_creation_with_gestor(self):
+        """Test creating a chat with a gestor ECA instead of a ciudadano"""
+        chat = ChatFactory.con_gestor()
+        self.assertIsInstance(chat, Chat)
+        self.assertEqual(chat.ciudadano.tipo_usuario, 'GECA')  # GESTOR_ECA code
+        self.assertIsNotNone(chat.punto)
+        self.assertIsNotNone(chat.created_at)
+
+class MensajeModelTestCase(TestCase):
+    def test_mensaje_creation(self):
+        mensaje = MensajeFactory()
+        self.assertIsInstance(mensaje, Mensaje)
+        self.assertFalse(mensaje.leido)
+        self.assertFalse(mensaje.editado)
+
+    def test_mensaje_creation_with_gestor(self):
+        """Test creating a message with a gestor ECA as sender"""
+        mensaje = MensajeFactory(remitente=UsuarioFactory.gestor())
+        self.assertIsInstance(mensaje, Mensaje)
+        self.assertEqual(mensaje.remitente.tipo_usuario, 'GECA')  # GESTOR_ECA code
+        self.assertFalse(mensaje.leido)
+        self.assertFalse(mensaje.editado)
+        self.assertIsNotNone(mensaje.chat)
+        self.assertIsNotNone(mensaje.texto)
+
+    def test_mark_as_leido(self):
+        mensaje = MensajeFactory()
+        mensaje.leido = True
+        mensaje.save()
+        self.assertTrue(mensaje.leido)
+
+    def test_edit_mensaje(self):
+        mensaje = MensajeFactory()
+        mensaje.texto = "Texto editado"
+        mensaje.editado = True
+        mensaje.save()
+        self.assertEqual(mensaje.texto, "Texto editado")
+        self.assertTrue(mensaje.editado)
+

--- a/apps/chat/tests/test_views.py
+++ b/apps/chat/tests/test_views.py
@@ -1,0 +1,216 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from apps.chat.tests.factories import UsuarioFactory, ChatFactory, MensajeFactory, PuntoECAFactory
+from apps.ecas.models import PuntoECA
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class ChatListCreateViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.usuario = UsuarioFactory()
+        self.chat_url = reverse('chat-list-create')
+
+    def test_chat_list_requires_authentication(self):
+        """Test that chat list endpoint requires authentication"""
+        response = self.client.get(self.chat_url)
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_chat_create_requires_authentication(self):
+        """Test that chat creation requires authentication"""
+        response = self.client.post(self.chat_url, {})
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_chat_list_returns_users_chats(self):
+        """Test that chat list returns only chats for the authenticated user"""
+        # Create chats for the authenticated user
+        chat1 = ChatFactory(ciudadano=self.usuario)
+        chat2 = ChatFactory(ciudadano=self.usuario)
+        
+        # Create a chat for another user (should not appear in results)
+        otro_usuario = UsuarioFactory()
+        chat3 = ChatFactory(ciudadano=otro_usuario)
+        
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.get(self.chat_url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        
+        # Verify the chats belong to the authenticated user
+        chat_ids = [chat['id'] for chat in response.data]
+        self.assertIn(chat1.id, chat_ids)
+        self.assertIn(chat2.id, chat_ids)
+        self.assertNotIn(chat3.id, chat_ids)
+
+    def test_chat_create_associates_with_authenticated_user(self):
+        """Test that creating a chat associates it with the authenticated user"""
+        punto = PuntoECAFactory()
+        
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.post(self.chat_url, {'punto': punto.id})
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['ciudadano'], self.usuario.id)
+        self.assertEqual(response.data['punto'], punto.id)
+
+
+class MensajeListCreateViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.usuario = UsuarioFactory()
+        self.chat = ChatFactory(ciudadano=self.usuario)
+        self.mensaje_url = reverse('mensaje-list-create', kwargs={'chat_id': self.chat.id})
+
+    def test_mensaje_list_requires_authentication(self):
+        """Test that mensaje list endpoint requires authentication"""
+        response = self.client.get(self.mensaje_url)
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_mensaje_create_requires_authentication(self):
+        """Test that mensaje creation requires authentication"""
+        response = self.client.post(self.mensaje_url, {})
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_mensaje_list_returns_messages_for_chat(self):
+        """Test that mensaje list returns only messages for the specified chat"""
+        # Create messages for this chat
+        mensaje1 = MensajeFactory(chat=self.chat)
+        mensaje2 = MensajeFactory(chat=self.chat)
+        
+        # Create a message for a different chat (should not appear in results)
+        otro_chat = ChatFactory()
+        mensaje3 = MensajeFactory(chat=otro_chat)
+        
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.get(self.mensaje_url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        
+        # Verify the messages belong to the correct chat
+        mensaje_ids = [mensaje['id'] for mensaje in response.data]
+        self.assertIn(mensaje1.id, mensaje_ids)
+        self.assertIn(mensaje2.id, mensaje_ids)
+        self.assertNotIn(mensaje3.id, mensaje_ids)
+
+    def test_mensaje_create_associates_with_authenticated_user_and_chat(self):
+        """Test that creating a mensaje associates it with the authenticated user and chat"""
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.post(self.mensaje_url, {'texto': 'Hola mundo'})
+        
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['remitente'], self.usuario.id)
+        self.assertEqual(response.data['chat'], self.chat.id)
+        self.assertEqual(response.data['texto'], 'Hola mundo')
+
+
+class MensajeUpdateViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.usuario = UsuarioFactory()
+        self.chat = ChatFactory(ciudadano=self.usuario)
+        self.mensaje = MensajeFactory(chat=self.chat, remitente=self.usuario)
+        self.update_url = reverse('mensaje-update', kwargs={
+            'chat_id': self.chat.id,
+            'mensaje_id': self.mensaje.id
+        })
+
+    def test_mensaje_update_requires_authentication(self):
+        """Test that mensaje update endpoint requires authentication"""
+        response = self.client.patch(self.update_url, {})
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_mensaje_update_only_by_remitente(self):
+        """Test that only the mensaje remitente can update it"""
+        otro_usuario = UsuarioFactory()
+        self.client.force_authenticate(user=otro_usuario)
+        response = self.client.patch(self.update_url, {'texto': 'Intento de hackeo'})
+        
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        
+        # Verify the mensaje was not updated
+        self.mensaje.refresh_from_db()
+        self.assertNotEqual(self.mensaje.texto, 'Intento de hackeo')
+
+    def test_mensaje_update_by_remitente_works(self):
+        """Test that the mensaje remitente can update their own message"""
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.patch(self.update_url, {'texto': 'Mensaje actualizado'})
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['texto'], 'Mensaje actualizado')
+        self.assertTrue(response.data['editado'])
+        
+        # Verify the mensaje was updated in the database
+        self.mensaje.refresh_from_db()
+        self.assertEqual(self.mensaje.texto, 'Mensaje actualizado')
+        self.assertTrue(self.mensaje.editado)
+
+    def test_mensaje_update_cannot_be_empty(self):
+        """Test that mensaje cannot be updated to empty text"""
+        self.client.force_authenticate(user=self.usuario)
+        response = self.client.patch(self.update_url, {'texto': ''}, content_type='application/json')
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_mensaje_update_nonexistent_mensaje_returns_404(self):
+        """Test that updating a nonexistent mensaje returns 404"""
+        self.client.force_authenticate(user=self.usuario)
+        url = reverse('mensaje-update', kwargs={
+            'chat_id': self.chat.id,
+            'mensaje_id': 99999  # Non-existent ID
+        })
+        response = self.client.patch(url, {'texto': 'Mensaje'})
+        
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class PuntoChatListViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('punto-chat-list')
+
+    def test_punto_chat_list_requires_authentication(self):
+        """Test that punto chat list endpoint requires authentication"""
+        response = self.client.get(self.url)
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_punto_chat_list_returns_empty_for_non_gestor(self):
+        """Test that punto chat list returns empty for non-gestor users"""
+        usuario_normal = UsuarioFactory()
+        self.client.force_authenticate(user=usuario_normal)
+        response = self.client.get(self.url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
+
+    def test_punto_chat_list_returns_chats_for_gestor(self):
+        """Test that punto chat list returns chats for gestor users"""
+        # Create a gestor user and associate them with a PuntoECA
+        gestor = UsuarioFactory.gestor()
+        punto = PuntoECAFactory(gestor_eca=gestor)
+        
+        # Create chats for this punto
+        chat1 = ChatFactory(punto=punto)
+        chat2 = ChatFactory(punto=punto)
+        
+        # Create a chat for a different punto (should not appear in results)
+        otro_punto = PuntoECAFactory()
+        chat3 = ChatFactory(punto=otro_punto)
+        
+        self.client.force_authenticate(user=gestor)
+        response = self.client.get(self.url)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        
+        # Verify the chats belong to the correct punto
+        chat_ids = [chat['id'] for chat in response.data]
+        self.assertIn(chat1.id, chat_ids)
+        self.assertIn(chat2.id, chat_ids)
+        self.assertNotIn(chat3.id, chat_ids)

--- a/apps/chat/views.py
+++ b/apps/chat/views.py
@@ -15,6 +15,7 @@ La lógica de permisos se basa en el usuario autenticado y la relación de perte
 
 from rest_framework import generics, permissions, serializers as drf_serializers
 from rest_framework.exceptions import PermissionDenied
+from django.http import Http404
 from apps.chat.models import Chat, Mensaje
 from apps.chat.serializers import ChatSerializer, MensajeSerializer
 from apps.ecas.models import PuntoECA
@@ -77,7 +78,8 @@ class MensajeUpdateView(generics.UpdateAPIView):
             chat_id=self.kwargs['chat_id']
         ).first()
         if not mensaje:
-            raise drf_serializers.ValidationError("Mensaje no encontrado.")
+            from django.http import Http404
+            raise Http404("Mensaje no encontrado.")
         if mensaje.remitente != self.request.user:
             raise PermissionDenied("Solo puedes editar tus propios mensajes.")
         return mensaje

--- a/apps/ecas/tests/factories.py
+++ b/apps/ecas/tests/factories.py
@@ -39,7 +39,7 @@ class PuntoECAFactory(DjangoModelFactory):
     nombre = Sequence(lambda n: f"Punto ECA {n}")
     descripcion = Faker("text", max_nb_chars=50)
     celular = Sequence(lambda n: f"3{n:09d}")
-    telefono_punto = Sequence(lambda n: f"60123456{n:02d}")
+    telefono_punto = Sequence(lambda n: f"60123456{(n % 100):02d}")
     direccion = Faker("address")
     logo_url_punto = Faker("url")
     foto_url_punto = Faker("url")

--- a/debug_auth.py
+++ b/debug_auth.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import os
+import django
+from django.conf import settings
+
+# Setup Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from rest_framework.test import APIClient
+from rest_framework import status
+from apps.chat.tests.factories import UsuarioFactory
+
+def debug_auth():
+    client = APIClient()
+    usuario = UsuarioFactory()
+    
+    print(f"Created user: {usuario.email}")
+    print(f"User ID: {usuario.id}")
+    print(f"User is_active: {usuario.is_active}")
+    
+    # Test login
+    response = client.post('/api/auth/login/', {'email': usuario.email, 'password': 'defaultpassword'}, format='json')
+    print(f"Login response status: {response.status_code}")
+    if response.status_code == 200:
+        print(f"Login response data: {response.data}")
+    
+    # Test chat endpoint without auth
+    client = APIClient()  # Fresh client
+    response = client.get('/api/chats/')
+    print(f"Chat list without auth - Status: {response.status_code}")
+    print(f"Chat list without auth - Content type: {response.get('Content-Type', 'None')}")
+    
+    # Test chat endpoint with auth
+    client.force_authenticate(user=usuario)
+    response = client.get('/api/chats/')
+    print(f"Chat list with auth - Status: {response.status_code}")
+    if response.status_code != 200:
+        print(f"Chat list with auth - Content: {response.content[:200]}")
+
+if __name__ == '__main__':
+    debug_auth()

--- a/debug_response.py
+++ b/debug_response.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import os
+import django
+from django.conf import settings
+
+# Setup Django
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from rest_framework.test import APIClient
+from rest_framework import status
+from apps.chat.tests.factories import UsuarioFactory, ChatFactory, MensajeFactory
+
+def debug_response():
+    client = APIClient()
+    usuario = UsuarioFactory()
+    chat = ChatFactory(ciudadano=usuario)
+    mensaje = MensajeFactory(chat=chat, remitente=usuario)
+    update_url = f'/api/chats/{chat.id}/mensajes/{mensaje.id}/'
+    
+    client.force_authenticate(user=usuario)
+    response = client.patch(update_url, {'texto': ''})
+    
+    print(f"Status code: {response.status_code}")
+    print(f"Response type: {type(response)}")
+    print(f"Has data attribute: {hasattr(response, 'data')}")
+    if hasattr(response, 'data'):
+        print(f"Response data: {response.data}")
+        print(f"Response data type: {type(response.data)}")
+    else:
+        print(f"Response content: {response.content}")
+        print(f"Response content type: {type(response.content)}")
+
+if __name__ == '__main__':
+    debug_response()


### PR DESCRIPTION
This pull request introduces comprehensive test coverage for the `apps/chat` app, including factories for test data creation, model tests, view tests for API endpoints, and debugging scripts. It also includes minor improvements and bug fixes related to test data generation and error handling.

**Test suite additions:**

* Added model factories for `Usuario`, `PuntoECA`, `Chat`, and `Mensaje` in `apps/chat/tests/factories.py` to streamline test data creation.
* Added model tests in `apps/chat/tests/test_models.py` to verify constraints, creation logic, and field behaviors for `Chat` and `Mensaje`.
* Added extensive API view tests in `apps/chat/tests/test_views.py` covering authentication, permissions, CRUD operations, and edge cases for chat and message endpoints.

**Debugging utilities:**

* Added `debug_auth.py` and `debug_response.py` scripts to facilitate manual testing and debugging of authentication and API responses. [[1]](diffhunk://#diff-34ae68e3f65dfe06c812ff26a3597821acceb0d2bbfe5931a66852554d403f04R1-R42) [[2]](diffhunk://#diff-753e13d9199db52408172747cc3215f9e5d23996c1eb629df1f59e9accc50db5R1-R35)

**Bug fixes and improvements:**

* Changed error handling in `apps/chat/views.py` to raise `Http404` instead of a validation error when a message is not found, improving RESTful response semantics. [[1]](diffhunk://#diff-8d5ad97c5395af86cdd45636998df12225733811a2d12064dc28485721b1e327L80-R82) [[2]](diffhunk://#diff-8d5ad97c5395af86cdd45636998df12225733811a2d12064dc28485721b1e327R18)
* Fixed phone number formatting in `apps/ecas/tests/factories.py` for more realistic test data.

**Cleanup:**

* Removed the empty default test file `apps/chat/tests.py`.-Pruebas unitarias para la app de chat