### PR TITLE
fix: cambiar patterns de URL de int a uuid para Notificacion y Chat

### DIFF
--- a/apps/chat/routing.py
+++ b/apps/chat/routing.py
@@ -22,6 +22,6 @@ from . import consumers
 # Lista de endpoints WebSocket utilizados por Django Channels.
 # - 'ws/chat/<chat_id>/': maneja un chat en tiempo real identificado por chat_id.
 websocket_urlpatterns = [
-    re_path(r"ws/chat/(?P<chat_id>\d+)/$", consumers.ChatConsumer.as_asgi()),
+    re_path(r"ws/chat/(?P<chat_id>[0-9a-f-]+)/$", consumers.ChatConsumer.as_asgi()),
 ]
 

--- a/apps/publicaciones/urls.py
+++ b/apps/publicaciones/urls.py
@@ -10,8 +10,8 @@ urlpatterns = [
     path("<uuid:publicacion_id>/comentar/", views.agregar_comentario, name="agregar_comentario"),
     path("<uuid:publicacion_id>/votar/", views.votar_publicacion, name="votar_publicacion"),
     path("<uuid:publicacion_id>/guardar/", views.toggle_guardado, name="toggle_guardado"),
-    path("notificacion/<int:notificacion_id>/abrir/", views.abrir_notificacion, name="abrir_notificacion"),
-    path("notificacion/<int:notificacion_id>/eliminar/", views.eliminar_notificacion, name="eliminar_notificacion"),
+    path("notificacion/<uuid:notificacion_id>/abrir/", views.abrir_notificacion, name="abrir_notificacion"),
+    path("notificacion/<uuid:notificacion_id>/eliminar/", views.eliminar_notificacion, name="eliminar_notificacion"),
     path("comentario/<uuid:comentario_id>/editar/", views.editar_comentario, name="editar_comentario"),
     path("comentario/<uuid:comentario_id>/eliminar/", views.eliminar_comentario, name="eliminar_comentario"),
 ]


### PR DESCRIPTION
- apps/publicaciones/urls.py: cambiar <int:notificacion_id> a <uuid:notificacion_id>
  en abrir_notificacion y eliminar_notificacion, ya que Notificacion.id es UUIDField
- apps/chat/routing.py: cambiar regex \d+ a [0-9a-f-]+ para chat_id, ya que Chat.id es UUIDField

Esto corrige HTTP 500 en /punto-eca/ (NoReverseMatch en template) y en /ws/chat/<uuid>/ (ValueError: No route found)