### PR TITLE
fix: convertir UUID a string en payloads de notificaciones en tiempo …

### DIFF
--- a/apps/chat/signals.py
+++ b/apps/chat/signals.py
@@ -22,7 +22,7 @@ def notificar_mensaje(sender, instance, created, **kwargs):
         nombre_ciudadano = chat.ciudadano.get_full_name() or chat.ciudadano.email
         notif = Notificacion.objects.create(usuario=gestor, mensaje=instance)
         enviar_notificacion_realtime(gestor.pk, {
-            "id": notif.pk,
+            "id": str(notif.pk),
             "tipo": "mensaje",
             "titulo": f"Nuevo mensaje de {nombre_ciudadano}: {instance.texto[:60]}",
             "fecha": notif.fecha_creacion.strftime("%d/%m/%Y %H:%M"),
@@ -32,7 +32,7 @@ def notificar_mensaje(sender, instance, created, **kwargs):
         # Gestor → notificar al ciudadano
         notif = Notificacion.objects.create(usuario=chat.ciudadano, mensaje=instance)
         enviar_notificacion_realtime(chat.ciudadano_id, {
-            "id": notif.pk,
+            "id": str(notif.pk),
             "tipo": "mensaje",
             "titulo": f"Nuevo mensaje de {chat.punto.nombre}: {instance.texto[:60]}",
             "fecha": notif.fecha_creacion.strftime("%d/%m/%Y %H:%M"),

--- a/apps/core/consumers.py
+++ b/apps/core/consumers.py
@@ -23,4 +23,4 @@ class NotificacionConsumer(AsyncWebsocketConsumer):
             await self.channel_layer.group_discard(self.group_name, self.channel_name)
 
     async def notificacion_nueva(self, event):
-        await self.send(text_data=json.dumps(event.get('data', {})))
+        await self.send(text_data=json.dumps(event.get('data', {}), default=str))

--- a/apps/ecas/views.py
+++ b/apps/ecas/views.py
@@ -192,7 +192,7 @@ def _check_upcoming_event_notifications(punto, usuario):
         )
         if created:
             enviar_notificacion_realtime(usuario.pk, {
-                "id": notif.pk,
+                "id": str(notif.pk),
                 "tipo": "evento",
                 "titulo": f"Evento próximo: {instancia.evento_base.titulo} — {instancia.fecha_inicio.strftime('%d/%m/%Y %H:%M')}",
                 "fecha": notif.fecha_creacion.strftime("%d/%m/%Y %H:%M"),

--- a/apps/inventory/signals.py
+++ b/apps/inventory/signals.py
@@ -40,7 +40,7 @@ def notificar_alerta_inventario(sender, instance, created, **kwargs):
     nivel = "crítico" if new_alerta == Alerta.CRITICO else "alerta"
     notif = Notificacion.objects.create(usuario=gestor, inventario=instance)
     enviar_notificacion_realtime(gestor.pk, {
-        "id": notif.pk,
+        "id": str(notif.pk),
         "tipo": "inventario",
         "titulo": f"Stock en {nivel}: {instance.material.nombre} ({instance.ocupacion_actual}% ocupado)",
         "fecha": notif.fecha_creacion.strftime("%d/%m/%Y %H:%M"),

--- a/apps/publicaciones/signals.py
+++ b/apps/publicaciones/signals.py
@@ -21,7 +21,7 @@ def notificar_nueva_publicacion(sender, instance, created, **kwargs):
     for destinatario in destinatarios:
         notif = Notificacion.objects.create(usuario=destinatario, publicacion=instance)
         enviar_notificacion_realtime(destinatario.pk, {
-            "id": notif.pk,
+            "id": str(notif.pk),
             "tipo": "publicacion",
             "titulo": instance.titulo,
             "fecha": notif.fecha_creacion.strftime("%d/%m/%Y %H:%M"),


### PR DESCRIPTION
…real

El error 'can not serialize UUID object' ocurría al crear publicaciones porque Notificacion.pk es uuid.UUID y se pasaba crudo en el dict de notificación hacia json.dumps().

- Convertir notif.pk a str() en cada call site (5 ocurrencias)
- Agregar default=str como safety net en json.dumps() del consumer WebSocket