### PR TITLE
fix: corregir link de Importar CSV en sidebar para que apunte a lista…

### DIFF
--- a/templates/admin/partials/sidebar.html
+++ b/templates/admin/partials/sidebar.html
@@ -25,7 +25,7 @@
                 <li><hr class="dropdown-divider my-1"></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_usuarios_pdf' %}"><i class="bi bi-file-earmark-pdf me-1"></i>Exportar PDF</a></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_usuarios_excel' %}"><i class="bi bi-file-earmark-excel me-1"></i>Exportar Excel</a></li>
-                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:importar_usuarios_csv' %}"><i class="bi bi-file-earmark-arrow-up me-1"></i>Importar CSV</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:listar_usuarios' %}"><i class="bi bi-file-earmark-arrow-up me-1"></i>Importar CSV</a></li>
             </ul>
         </li>
 


### PR DESCRIPTION
…r_usuarios

El sidebar tenia un enlace directo a la vista importar_usuarios_csv que solo acepta POST (decorada con @require_POST). Al hacer clic se producia un error 405 Method Not Allowed.

Se cambia el href a listar_usuarios, que es la pagina donde se encuentra el boton y modal de Importar CSV con el formulario POST correcto.