### PR TITLE
fix: modal Importar CSV no se abria y mensajes SweetAlert no se mostr…

### DIFF
--- a/apps/panel_admin/views.py
+++ b/apps/panel_admin/views.py
@@ -1023,8 +1023,10 @@ def exportar_usuarios_excel(request):
 
 @login_required(login_url="/login/")
 @user_passes_test(es_administrador, login_url="/inicio/")
-@require_POST
+@require_http_methods(["GET", "POST"])
 def importar_usuarios_csv(request):
+    if request.method == "GET":
+        return redirect(ADMIN_LISTAR_USUARIOS_URL)
 
     archivo = request.FILES.get("archivo_csv")
     if not archivo:

--- a/templates/admin/Usuarios/listUsuario.html
+++ b/templates/admin/Usuarios/listUsuario.html
@@ -20,36 +20,6 @@
     </div>
   </div>
 
-  <!-- Modal Importar CSV -->
-  <div class="modal fade" id="modalImportCSV" tabindex="-1" aria-labelledby="modalImportCSVLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header bg-success text-white">
-          <h5 class="modal-title" id="modalImportCSVLabel"><i class="bi bi-upload me-2"></i>Importar usuarios desde CSV</h5>
-          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
-        </div>
-        <form method="post" enctype="multipart/form-data" action="{% url 'panel_admin:importar_usuarios_csv' %}">
-          {% csrf_token %}
-          <div class="modal-body">
-            <p class="text-muted small mb-3">El archivo CSV debe tener las siguientes columnas:</p>
-            <div class="bg-light border rounded p-2 mb-3">
-              <code class="small">nombres, apellidos, email, celular, password, tipo_usuario*, tipo_documento*, numero_documento*, ciudad*</code>
-            </div>
-            <p class="small text-muted mb-3">* Opcionales. Valores válidos para <strong>tipo_usuario</strong>: <code>ADM</code>, <code>CIU</code>, <code>GECA</code>. Para <strong>tipo_documento</strong>: <code>CC</code>, <code>TI</code>, <code>CE</code>, <code>PA</code>, <code>NIT</code>.</p>
-            <div class="mb-3">
-              <label for="import_archivo_csv" class="form-label fw-semibold">Archivo CSV <span class="text-danger">*</span> <small class="text-muted fw-normal">(requerido)</small></label>
-              <input id="import_archivo_csv" type="file" name="archivo_csv" class="form-control" accept=".csv" required>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button type="submit" class="btn btn-success"><i class="bi bi-upload me-1"></i> Importar</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-
   <!-- Charts -->
   <div class="row g-3 mb-4">
     <div class="col-12 col-lg-4">
@@ -185,6 +155,36 @@
 {% endblock %}
 
 {% block extra_modals %}
+<!-- ===== MODAL IMPORTAR CSV ===== -->
+<div class="modal fade" id="modalImportCSV" tabindex="-1" aria-labelledby="modalImportCSVLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-success text-white">
+        <h5 class="modal-title" id="modalImportCSVLabel"><i class="bi bi-upload me-2"></i>Importar usuarios desde CSV</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      </div>
+      <form method="post" enctype="multipart/form-data" action="{% url 'panel_admin:importar_usuarios_csv' %}">
+        {% csrf_token %}
+        <div class="modal-body">
+          <p class="text-muted small mb-3">El archivo CSV debe tener las siguientes columnas:</p>
+          <div class="bg-light border rounded p-2 mb-3">
+            <code class="small">nombres, apellidos, email, celular, password, tipo_usuario*, tipo_documento*, numero_documento*, ciudad*</code>
+          </div>
+          <p class="small text-muted mb-3">* Opcionales. Valores válidos para <strong>tipo_usuario</strong>: <code>ADM</code>, <code>CIU</code>, <code>GECA</code>. Para <strong>tipo_documento</strong>: <code>CC</code>, <code>TI</code>, <code>CE</code>, <code>PA</code>, <code>NIT</code>.</p>
+          <div class="mb-3">
+            <label for="import_archivo_csv" class="form-label fw-semibold">Archivo CSV <span class="text-danger">*</span> <small class="text-muted fw-normal">(requerido)</small></label>
+            <input id="import_archivo_csv" type="file" name="archivo_csv" class="form-control" accept=".csv" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-success"><i class="bi bi-upload me-1"></i> Importar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
 <!-- ===== MODAL EDITAR USUARIO ===== -->
 <div class="modal fade" id="modalEditarUsuario" tabindex="-1" aria-labelledby="labelEditarUsuario" aria-hidden="true">
   <div class="modal-dialog modal-lg">
@@ -277,7 +277,6 @@
 {% endblock %}
 
 {% block extra_scripts %}
-{% include "admin/_messages_swal.html" %}
 <script src="{% static 'js/admin/usuario-form-comun.js' %}"></script>
 <script>
 AdminCharts.initAll([

--- a/templates/admin/_messages_swal.html
+++ b/templates/admin/_messages_swal.html
@@ -2,29 +2,26 @@
   {% for first_message in messages %}
     {% if forloop.first %}
   <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      if (typeof Swal === "undefined") {
-        return;
-      }
-
-      const mapaTitulos = {
-        success: "Operación exitosa",
-        error: "No se pudo completar la operación",
-        danger: "No se pudo completar la operación",
-        warning: "Atención",
-        info: "Información",
-        debug: "Información",
-      };
-      const tag = "{{ first_message.tags|default:'info'|escapejs }}";
-      const titulo = mapaTitulos[tag] || "Notificación";
-
-      Swal.fire({
-        icon: tag === "danger" ? "error" : tag,
-        title: titulo,
-        text: "{{ first_message|escapejs }}",
-        confirmButtonColor: "#198754",
-      });
-    });
+    if (typeof Swal !== "undefined") {
+      (function() {
+        var mapaTitulos = {
+          success: "Operación exitosa",
+          error: "No se pudo completar la operación",
+          danger: "No se pudo completar la operación",
+          warning: "Atención",
+          info: "Información",
+          debug: "Información",
+        };
+        var tag = "{{ first_message.tags|default:'info'|escapejs }}";
+        var titulo = mapaTitulos[tag] || "Notificación";
+        Swal.fire({
+          icon: tag === "danger" ? "error" : tag,
+          title: titulo,
+          text: "{{ first_message|escapejs }}",
+          confirmButtonColor: "#198754",
+        });
+      })();
+    }
   </script>
     {% endif %}
   {% endfor %}

--- a/templates/admin/partials/sidebar.html
+++ b/templates/admin/partials/sidebar.html
@@ -25,7 +25,7 @@
                 <li><hr class="dropdown-divider my-1"></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_usuarios_pdf' %}"><i class="bi bi-file-earmark-pdf me-1"></i>Exportar PDF</a></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_usuarios_excel' %}"><i class="bi bi-file-earmark-excel me-1"></i>Exportar Excel</a></li>
-                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:listar_usuarios' %}"><i class="bi bi-file-earmark-arrow-up me-1"></i>Importar CSV</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:importar_usuarios_csv' %}"><i class="bi bi-file-earmark-arrow-up me-1"></i>Importar CSV</a></li>
             </ul>
         </li>
 


### PR DESCRIPTION
…aban

- Mover modal Importar CSV de block content a block extra_modals (Bootstrap recomienda modals fuera de contenedores con flex/overflow)
- Vista importar_usuarios_csv ahora acepta GET y redirige a listar_usuarios (sidebar apunta a esta URL, igual que Export)
- Reparar _messages_swal.html: DOMContentLoaded nunca se disparaba al estar el script al final del body
- Eliminar include duplicado de _messages_swal.html en listUsuario