### PR TITLE
fix: mover .chat-msg-time fuera de .chat-msg-bubble para que md() no …

### DIFF
--- a/apps/reciclabot/views.py
+++ b/apps/reciclabot/views.py
@@ -32,15 +32,17 @@ def asistente_api_view(request):
         '<div class="chat-msg-avatar chat-msg-avatar-user">👤</div>'
         '<div class="chat-msg-bubble">'
         + escape(pregunta) +
+        '</div>'
         '<div class="chat-msg-time"></div>'
-        '</div></div>'
+        '</div>'
     )
     ai_msg = (
         '<div class="chat-msg-ai">'
         '<div class="chat-msg-avatar chat-msg-avatar-ai">🤖</div>'
         '<div class="chat-msg-bubble">'
         + escape(respuesta) +
+        '</div>'
         '<div class="chat-msg-time"></div>'
-        '</div></div>'
+        '</div>'
     )
     return HttpResponse(user_msg + ai_msg)


### PR DESCRIPTION
…lo escape a texto plano

El bug: md(bubble.innerHTML) procesa todo el HTML interno del bubble, incluyendo el <div class="chat-msg-time"> estructural. Al hacer replaceAll('<', '&lt;') lo convierte en texto plano visible.

Solución: separar .chat-msg-time como hermano de .chat-msg-bubble, asi bubble.innerHTML solo contiene el texto del mensaje.