### PR TITLE
fix(tests): migrar Material(tipo=) a Material(clasificacion=)

### DIFF
--- a/apps/chat/tests/factories.py
+++ b/apps/chat/tests/factories.py
@@ -10,7 +10,7 @@ class UsuarioFactory(factory.django.DjangoModelFactory):
 
     email = factory.Sequence(lambda n: f"user{n}@example.com")
     nombres = factory.Faker("first_name")
-    apellidos = factory.Faker("last_name")
+    apellidos = factory.Sequence(lambda n: f"Apellido{n}")
     tipo_documento = "CC"
     numero_documento = factory.Sequence(lambda n: f"123456{n}")
     fecha_nacimiento = "1990-01-01"

--- a/apps/inventory/tests/test_inventario_alerta.py
+++ b/apps/inventory/tests/test_inventario_alerta.py
@@ -12,7 +12,6 @@ from apps.inventory.models import (
     CategoriaMaterial,
     Inventario,
     Material,
-    TipoMaterial,
 )
 from apps.users.models import Usuario
 
@@ -47,11 +46,8 @@ def _crear_punto_y_material():
     cat, _ = CategoriaMaterial.objects.get_or_create(
         nombre=f"C{uuid.uuid4().hex[:4]}"
     )
-    tip, _ = TipoMaterial.objects.get_or_create(
-        nombre=f"T{uuid.uuid4().hex[:4]}"
-    )
     mat = Material.objects.create(
-        nombre=f"M{uuid.uuid4().hex[:4]}", categoria=cat, tipo=tip
+        nombre=f"M{uuid.uuid4().hex[:4]}", categoria=cat, clasificacion="ESTANDAR"
     )
     return p, mat
 

--- a/apps/operations/tests.py
+++ b/apps/operations/tests.py
@@ -80,7 +80,7 @@ class TestExportHistorialFiltrosAvanzados(TestCase):
         self.mat = Material.objects.create(
             nombre="Lata Test",
             categoria=self.categoria_metal,
-            tipo=self.tipo_alum,
+            clasificacion="ESTANDAR",
         )
         self.inv = Inventario.objects.create(
             punto_eca=self.punto,
@@ -209,7 +209,7 @@ class TestExportHistorialFiltrosAvanzados(TestCase):
         response = self._exportar_excel(
             material="Lata Test",
             categoria="Metales",
-            tipo="Aluminio",
+            tipo="ESTANDAR",
             fecha_desde="2024-06-01",
             fecha_hasta="2024-06-30",
             cantidad_min=10,
@@ -251,7 +251,7 @@ class TestExportFilename(TestCase):
         cls.categoria = CategoriaMaterial.objects.create(nombre="Metales")
         cls.tipo = TipoMaterial.objects.create(nombre="Aluminio")
         cls.mat = Material.objects.create(
-            nombre="Lata Test", categoria=cls.categoria, tipo=cls.tipo
+            nombre="Lata Test", categoria=cls.categoria, clasificacion="ESTANDAR"
         )
         cls.inv = Inventario.objects.create(
             punto_eca=cls.punto,
@@ -371,7 +371,7 @@ class TestEditarMovimiento(TestCase):
             gestor_eca=cls.user,
         )
         cls.mat = Material.objects.create(
-            nombre="Lata Edit", categoria=cls.categoria, tipo=cls.tipo
+            nombre="Lata Edit", categoria=cls.categoria, clasificacion="ESTANDAR"
         )
         cls.inv = Inventario.objects.create(
             punto_eca=cls.punto,
@@ -516,7 +516,7 @@ class TestFlujoEndToEndCompraInventario(TestCase):
             gestor_eca=cls.user,
         )
         cls.mat = Material.objects.create(
-            nombre="Lata E2E", categoria=cls.categoria, tipo=cls.tipo
+            nombre="Lata E2E", categoria=cls.categoria, clasificacion="ESTANDAR"
         )
         cls.inv = Inventario.objects.create(
             punto_eca=cls.punto,
@@ -753,7 +753,7 @@ class TestBulkImportEndpoint(TestCase):
             gestor_eca=cls.user,
         )
         cls.mat = Material.objects.create(
-            nombre="Lata Bulk", categoria=cls.categoria, tipo=cls.tipo
+            nombre="Lata Bulk", categoria=cls.categoria, clasificacion="ESTANDAR"
         )
         cls.inv = Inventario.objects.create(
             punto_eca=cls.punto,
@@ -866,7 +866,7 @@ class TestBulkImportEndpoint(TestCase):
         cat2 = CategoriaMaterial.objects.create(nombre="Plásticos")
         tipo2 = TipoMaterial.objects.create(nombre="PET")
         mat_nuevo = Material.objects.create(
-            nombre="Material Catalogo Nuevo", categoria=cat2, tipo=tipo2
+            nombre="Material Catalogo Nuevo", categoria=cat2, clasificacion="ESTANDAR"
         )
         self.assertFalse(
             Inventario.objects.filter(punto_eca=self.punto, material=mat_nuevo).exists()
@@ -977,7 +977,7 @@ class TestBulkImportEndpoint(TestCase):
         tipo = TipoMaterial.objects.first() or TipoMaterial.objects.create(nombre="Default")
         for nombre in nombres:
             if not Material.objects.filter(nombre=nombre).exists():
-                Material.objects.create(nombre=nombre, categoria=cat, tipo=tipo)
+                Material.objects.create(nombre=nombre, categoria=cat, clasificacion="ESTANDAR")
 
     # --- Endpoint descargar_plantilla_bulk ---
 


### PR DESCRIPTION
## Problema
El PR #172 eliminó el campo FK `tipo` del modelo `Material` pero los tests aún pasaban `tipo=` al crear materiales, causando 23 errores en CI:

```
TypeError: Material() got unexpected keyword arguments: 'tipo'
```

## Cambios

- **test_inventario_alerta.py**: Eliminado `TipoMaterial` y `tip` no usados, `tipo=tip` → `clasificacion="ESTANDAR"`
- **operations/tests.py**: 7 llamadas `Material.objects.create(tipo=...)` → `clasificacion="ESTANDAR"`, filtro export `tipo="Aluminio"` → `tipo="ESTANDAR"`
- **chat/tests/factories.py**: `Faker("last_name")` → `Sequence(lambda n: f"Apellido{n}")` (evita apellidos < 3 chars que fallan `MinLengthValidator`)

## Verificación
- `python manage.py test apps.chat apps.inventory apps.map apps.operations apps.scheduling apps.core apps.panel_admin` → **127 tests OK** (2 skipped)
- `python manage.py check` → 0 issues