### PR TITLE
fix: corregir eliminación de notificaciones

### DIFF
--- a/apps/ecas/views.py
+++ b/apps/ecas/views.py
@@ -164,11 +164,11 @@ def render_seccion(request, seccion="resumen", perfil_tab="punto"):
     else:
         context = _build_default_context(punto, seccion)
 
-    _add_notificacion_context(punto, request.user, context)
+    _add_notificacion_context(punto, request.user, context, request=request)
     return render(request, "ecas/puntoECA-layout.html", context)
 
 
-def _check_upcoming_event_notifications(punto, usuario):
+def _check_upcoming_event_notifications(punto, usuario, eliminadas=None):
     """Crea notificaciones para eventos que ocurren en las próximas 24 horas si aún no existen."""
     from apps.scheduling.models import EventoInstancia
     from apps.publicaciones.models import Notificacion
@@ -177,6 +177,7 @@ def _check_upcoming_event_notifications(punto, usuario):
 
     ahora = timezone.now()
     limite = ahora + timedelta(hours=24)
+    eliminadas = eliminadas or []
 
     proximos = EventoInstancia.objects.filter(
         punto_eca=punto,
@@ -186,6 +187,8 @@ def _check_upcoming_event_notifications(punto, usuario):
     ).select_related("evento_base")
 
     for instancia in proximos:
+        if str(instancia.pk) in eliminadas:
+            continue
         notif, created = Notificacion.objects.get_or_create(
             usuario=usuario,
             evento_instancia=instancia,
@@ -201,10 +204,11 @@ def _check_upcoming_event_notifications(punto, usuario):
             })
 
 
-def _add_notificacion_context(punto, usuario, context):
+def _add_notificacion_context(punto, usuario, context, request=None):
     from apps.publicaciones.models import Notificacion
 
-    _check_upcoming_event_notifications(punto, usuario)
+    eliminadas = request.session.get('_notif_evento_eliminadas', []) if request else []
+    _check_upcoming_event_notifications(punto, usuario, eliminadas=eliminadas)
     context["mis_notificaciones"] = (
         Notificacion.objects.filter(usuario=usuario)
         .select_related(

--- a/apps/publicaciones/tests.py
+++ b/apps/publicaciones/tests.py
@@ -1,0 +1,204 @@
+import uuid
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+from apps.publicaciones.models import Notificacion
+from config import constants as cons
+
+Usuario = get_user_model()
+
+_URL_ELIMINAR = "publicacion:eliminar_notificacion"
+
+
+class EliminarNotificacionTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.ciudadano = Usuario.objects.create_user(
+            email="ciudadano@test.com",
+            numero_documento="111111",
+            password="TestPass1!",
+            nombres="Ciudadano",
+            apellidos="Test",
+            tipo_usuario=cons.TipoUsuario.CIUDADANO,
+        )
+        cls.gestor = Usuario.objects.create_user(
+            email="gestor@test.com",
+            numero_documento="222222",
+            password="TestPass2!",
+            nombres="Gestor",
+            apellidos="Test",
+            tipo_usuario=cons.TipoUsuario.GESTOR_ECA,
+        )
+        cls.otro_ciudadano = Usuario.objects.create_user(
+            email="otro@test.com",
+            numero_documento="333333",
+            password="TestPass3!",
+            nombres="Otro",
+            apellidos="Test",
+            tipo_usuario=cons.TipoUsuario.CIUDADANO,
+        )
+
+    def _crear_notificacion(self, usuario, **kwargs):
+        return Notificacion.objects.create(usuario=usuario, **kwargs)
+
+    def _url(self, notificacion):
+        return reverse(_URL_ELIMINAR, kwargs={"notificacion_id": notificacion.pk})
+
+    # ── POST elimina notificación propia ────────────────────────────────────
+
+    def test_post_elimina_notificacion_propia(self):
+        notif = self._crear_notificacion(self.ciudadano)
+        self.client.force_login(self.ciudadano)
+
+        response = self.client.post(self._url(notif))
+
+        self.assertRedirects(response, reverse("perfil_ciudadano"))
+        self.assertFalse(Notificacion.objects.filter(pk=notif.pk).exists())
+
+    def test_post_elimina_notificacion_gestor(self):
+        notif = self._crear_notificacion(self.gestor)
+        self.client.force_login(self.gestor)
+
+        response = self.client.post(self._url(notif))
+
+        self.assertRedirects(response, "/punto-eca/", fetch_redirect_response=False)
+        self.assertFalse(Notificacion.objects.filter(pk=notif.pk).exists())
+
+    # ── GET devuelve 405 ─────────────────────────────────────────────────────
+
+    def test_get_devuelve_405(self):
+        notif = self._crear_notificacion(self.ciudadano)
+        self.client.force_login(self.ciudadano)
+
+        response = self.client.get(self._url(notif))
+
+        self.assertEqual(response.status_code, 405)
+        self.assertTrue(Notificacion.objects.filter(pk=notif.pk).exists())
+
+    # ── No puede eliminar notificación ajena ─────────────────────────────────
+
+    def test_no_elimina_notificacion_ajena(self):
+        notif = self._crear_notificacion(self.ciudadano)
+        self.client.force_login(self.otro_ciudadano)
+
+        response = self.client.post(self._url(notif))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(Notificacion.objects.filter(pk=notif.pk).exists())
+
+    # ── Requiere autenticación ───────────────────────────────────────────────
+
+    def test_requiere_autenticacion(self):
+        notif = self._crear_notificacion(self.ciudadano)
+        response = self.client.post(self._url(notif))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.url)
+
+    # ── Sesión guarda evento_instancia_id al eliminar ────────────────────────
+
+    def test_sesion_guarda_evento_id_al_eliminar(self):
+        evento_id = uuid.uuid4()
+        from apps.ecas.models import PuntoECA
+        from apps.scheduling.models import Evento, EventoInstancia
+        from apps.inventory.models import Material, CategoriaMaterial
+
+        punto = PuntoECA.objects.create(
+            gestor_eca=self.gestor,
+            nombre="Punto Test",
+        )
+        categoria = CategoriaMaterial.objects.create(nombre="Cat Test")
+        material = Material.objects.create(
+            nombre="Material Test",
+            categoria=categoria,
+        )
+        evento = Evento.objects.create(
+            material=material,
+            punto_eca=punto,
+            usuario=self.gestor,
+            titulo="Evento Test",
+            fecha_inicio=timezone.now(),
+            fecha_fin=timezone.now() + timedelta(hours=1),
+        )
+        instancia = EventoInstancia.objects.create(
+            evento_base=evento,
+            punto_eca=punto,
+            usuario=self.gestor,
+            fecha_inicio=timezone.now() + timedelta(hours=2),
+            fecha_fin=timezone.now() + timedelta(hours=3),
+        )
+
+        notif = Notificacion.objects.create(
+            usuario=self.gestor,
+            evento_instancia=instancia,
+        )
+        self.client.force_login(self.gestor)
+
+        self.client.post(self._url(notif))
+
+        session = self.client.session
+        eliminadas = session.get("_notif_evento_eliminadas", [])
+        self.assertIn(str(instancia.pk), eliminadas)
+
+    # ── _check_upcoming_event_notifications no recrea eventos eliminados ─────
+
+    def test_evento_eliminado_no_se_recrea(self):
+        from apps.ecas.models import PuntoECA
+        from apps.scheduling.models import Evento, EventoInstancia
+        from apps.inventory.models import Material, CategoriaMaterial
+        from apps.ecas.views import _check_upcoming_event_notifications
+
+        punto = PuntoECA.objects.create(
+            gestor_eca=self.gestor,
+            nombre="Punto Test 2",
+        )
+        categoria = CategoriaMaterial.objects.create(nombre="Cat Test 2")
+        material = Material.objects.create(
+            nombre="Material Test 2",
+            categoria=categoria,
+        )
+        ahora = timezone.now()
+        evento = Evento.objects.create(
+            material=material,
+            punto_eca=punto,
+            usuario=self.gestor,
+            titulo="Evento Proximo",
+            fecha_inicio=ahora,
+            fecha_fin=ahora + timedelta(hours=1),
+        )
+        instancia = EventoInstancia.objects.create(
+            evento_base=evento,
+            punto_eca=punto,
+            usuario=self.gestor,
+            fecha_inicio=ahora + timedelta(hours=2),
+            fecha_fin=ahora + timedelta(hours=3),
+            es_completado=False,
+        )
+
+        # Primero verificar que se crea sin el filtro de eliminadas
+        Notificacion.objects.filter(
+            usuario=self.gestor, evento_instancia=instancia
+        ).delete()
+        _check_upcoming_event_notifications(punto, self.gestor)
+        self.assertTrue(
+            Notificacion.objects.filter(
+                usuario=self.gestor, evento_instancia=instancia
+            ).exists(),
+            "Debe crear la notificación cuando no está en la lista de eliminadas",
+        )
+
+        # Eliminarla y pasar la lista de eliminadas
+        Notificacion.objects.filter(
+            usuario=self.gestor, evento_instancia=instancia
+        ).delete()
+        eliminadas = [str(instancia.pk)]
+        _check_upcoming_event_notifications(punto, self.gestor, eliminadas=eliminadas)
+        self.assertFalse(
+            Notificacion.objects.filter(
+                usuario=self.gestor, evento_instancia=instancia
+            ).exists(),
+            "No debe recrear la notificación si el evento está en la lista de eliminadas",
+        )

--- a/apps/publicaciones/tests.py
+++ b/apps/publicaciones/tests.py
@@ -1,5 +1,3 @@
-import secrets
-import string
 from datetime import timedelta
 
 from django.test import TestCase
@@ -8,26 +6,12 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 
 from apps.publicaciones.models import Notificacion
+from apps.users.tests import _generar_password
 from config import constants as cons
 
 Usuario = get_user_model()
 
 _URL_ELIMINAR = "publicacion:eliminar_notificacion"
-
-
-def _generar_password():
-    simbolos = "@$!%*?&"
-    alphabet = string.ascii_letters + string.digits + simbolos
-    while True:
-        pwd = "".join(secrets.choice(alphabet) for _ in range(16))
-        if (
-            any(c.isupper() for c in pwd)
-            and any(c.islower() for c in pwd)
-            and any(c.isdigit() for c in pwd)
-            and any(c in simbolos for c in pwd)
-        ):
-            return pwd
-
 
 _PWD_TEST = _generar_password()
 

--- a/apps/publicaciones/tests.py
+++ b/apps/publicaciones/tests.py
@@ -1,4 +1,5 @@
-import uuid
+import secrets
+import string
 from datetime import timedelta
 
 from django.test import TestCase
@@ -14,13 +15,30 @@ Usuario = get_user_model()
 _URL_ELIMINAR = "publicacion:eliminar_notificacion"
 
 
+def _generar_password():
+    simbolos = "@$!%*?&"
+    alphabet = string.ascii_letters + string.digits + simbolos
+    while True:
+        pwd = "".join(secrets.choice(alphabet) for _ in range(16))
+        if (
+            any(c.isupper() for c in pwd)
+            and any(c.islower() for c in pwd)
+            and any(c.isdigit() for c in pwd)
+            and any(c in simbolos for c in pwd)
+        ):
+            return pwd
+
+
+_PWD_TEST = _generar_password()
+
+
 class EliminarNotificacionTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.ciudadano = Usuario.objects.create_user(
             email="ciudadano@test.com",
             numero_documento="111111",
-            password="TestPass1!",
+            password=_PWD_TEST,
             nombres="Ciudadano",
             apellidos="Test",
             tipo_usuario=cons.TipoUsuario.CIUDADANO,
@@ -28,7 +46,7 @@ class EliminarNotificacionTests(TestCase):
         cls.gestor = Usuario.objects.create_user(
             email="gestor@test.com",
             numero_documento="222222",
-            password="TestPass2!",
+            password=_PWD_TEST,
             nombres="Gestor",
             apellidos="Test",
             tipo_usuario=cons.TipoUsuario.GESTOR_ECA,
@@ -36,7 +54,7 @@ class EliminarNotificacionTests(TestCase):
         cls.otro_ciudadano = Usuario.objects.create_user(
             email="otro@test.com",
             numero_documento="333333",
-            password="TestPass3!",
+            password=_PWD_TEST,
             nombres="Otro",
             apellidos="Test",
             tipo_usuario=cons.TipoUsuario.CIUDADANO,
@@ -101,7 +119,6 @@ class EliminarNotificacionTests(TestCase):
     # ── Sesión guarda evento_instancia_id al eliminar ────────────────────────
 
     def test_sesion_guarda_evento_id_al_eliminar(self):
-        evento_id = uuid.uuid4()
         from apps.ecas.models import PuntoECA
         from apps.scheduling.models import Evento, EventoInstancia
         from apps.inventory.models import Material, CategoriaMaterial

--- a/apps/publicaciones/views.py
+++ b/apps/publicaciones/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_POST
 
 _COMENTARIO_MIN = 1
 _COMENTARIO_MAX = 1000
@@ -122,11 +122,11 @@ def abrir_notificacion(request, notificacion_id):
 
 
 @login_required
+@require_POST
 def eliminar_notificacion(request, notificacion_id):
-    if request.method == "POST":
-        from .models import Notificacion
-        notificacion = get_object_or_404(Notificacion, pk=notificacion_id, usuario=request.user)
-        notificacion.delete()
+    from .models import Notificacion
+    notificacion = get_object_or_404(Notificacion, pk=notificacion_id, usuario=request.user)
+    notificacion.delete()
     from config.constants import TipoUsuario
     if request.user.tipo_usuario == TipoUsuario.GESTOR_ECA:
         return redirect("/punto-eca/")

--- a/apps/publicaciones/views.py
+++ b/apps/publicaciones/views.py
@@ -126,7 +126,14 @@ def abrir_notificacion(request, notificacion_id):
 def eliminar_notificacion(request, notificacion_id):
     from .models import Notificacion
     notificacion = get_object_or_404(Notificacion, pk=notificacion_id, usuario=request.user)
+    evento_id = notificacion.evento_instancia_id
     notificacion.delete()
+    if evento_id:
+        if '_notif_evento_eliminadas' not in request.session:
+            request.session['_notif_evento_eliminadas'] = []
+        if str(evento_id) not in request.session['_notif_evento_eliminadas']:
+            request.session['_notif_evento_eliminadas'].append(str(evento_id))
+            request.session.modified = True
     from config.constants import TipoUsuario
     if request.user.tipo_usuario == TipoUsuario.GESTOR_ECA:
         return redirect("/punto-eca/")

--- a/static/js/notificaciones_ws.js
+++ b/static/js/notificaciones_ws.js
@@ -1,3 +1,15 @@
+function getCookie(name) {
+    if (!document.cookie) return '';
+    const cookies = document.cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i].trim();
+        if (cookie.startsWith(name + '=')) {
+            return decodeURIComponent(cookie.substring(name.length + 1));
+        }
+    }
+    return '';
+}
+
 function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill') {
     const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
     const ws = new WebSocket(`${protocol}://${location.host}/ws/notificaciones/`);
@@ -27,10 +39,13 @@ function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill')
         if (empty) empty.remove();
 
         const icon = iconMap?.[data.tipo] || defaultIcon;
+        const csrfToken = getCookie('csrftoken');
         const item = document.createElement('div');
         item.className = 'dropdown-item d-flex gap-2 align-items-start py-2 px-3 border-bottom bg-warning-subtle';
         item.style.whiteSpace = 'normal';
         item.dataset.notifId = data.id;
+
+        const deleteUrl = `/publicaciones/notificacion/${encodeURIComponent(data.id)}/eliminar/`;
         item.innerHTML = `
             <a href="${data.url}" class="d-flex gap-2 align-items-start flex-grow-1 text-decoration-none text-reset">
                 <span class="rounded-circle bg-success-subtle text-success d-flex align-items-center justify-content-center flex-shrink-0 mt-1" style="width:32px;height:32px;">
@@ -41,7 +56,14 @@ function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill')
                     <span class="d-block text-muted" style="font-size:.72rem;"><i class="bi bi-clock me-1"></i>${data.fecha}</span>
                 </span>
                 <span class="badge rounded-pill bg-success align-self-center" style="font-size:.55rem;">Nueva</span>
-            </a>`;
+            </a>
+            <form method="POST" action="${deleteUrl}" class="ms-1 flex-shrink-0"
+                  onsubmit="return confirm('¿Eliminar esta notificación?');">
+                <input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">
+                <button type="submit" class="btn btn-sm btn-link text-muted p-0" title="Eliminar notificación" aria-label="Eliminar notificación">
+                    <i class="bi bi-x-lg"></i>
+                </button>
+            </form>`;
 
         const header = menu.querySelector('.px-3.py-2.border-bottom.bg-light');
         if (header?.nextSibling) {

--- a/static/js/notificaciones_ws.js
+++ b/static/js/notificaciones_ws.js
@@ -74,14 +74,14 @@ function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill')
 }
 
 function initNotificacionEliminar(dropdownId) {
-    var menu = document.querySelector(`[aria-labelledby="${dropdownId}"]`);
+    const menu = document.querySelector(`[aria-labelledby="${dropdownId}"]`);
     if (!menu) return;
     menu.addEventListener('click', function(e) {
-        var btn = e.target.closest('.notificacion-eliminar-btn');
+        const btn = e.target.closest('.notificacion-eliminar-btn');
         if (!btn) return;
         e.preventDefault();
         e.stopPropagation();
-        var form = btn.closest('.notificacion-eliminar-form');
+        const form = btn.closest('.notificacion-eliminar-form');
         Swal.fire({
             title: '¿Eliminar esta notificación?',
             text: 'Esta acción no se puede deshacer.',

--- a/static/js/notificaciones_ws.js
+++ b/static/js/notificaciones_ws.js
@@ -72,3 +72,29 @@ function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill')
         }
     };
 }
+
+function initNotificacionEliminar(dropdownId) {
+    var menu = document.querySelector(`[aria-labelledby="${dropdownId}"]`);
+    if (!menu) return;
+    menu.addEventListener('click', function(e) {
+        var btn = e.target.closest('.notificacion-eliminar-btn');
+        if (!btn) return;
+        e.preventDefault();
+        e.stopPropagation();
+        var form = btn.closest('.notificacion-eliminar-form');
+        Swal.fire({
+            title: '¿Eliminar esta notificación?',
+            text: 'Esta acción no se puede deshacer.',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#198754',
+            cancelButtonColor: '#6c757d',
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+        }).then(function(result) {
+            if (result.isConfirmed) {
+                form.submit();
+            }
+        });
+    });
+}

--- a/static/js/notificaciones_ws.js
+++ b/static/js/notificaciones_ws.js
@@ -57,10 +57,9 @@ function initNotificacionesWS(dropdownId, iconMap, defaultIcon = 'bi-bell-fill')
                 </span>
                 <span class="badge rounded-pill bg-success align-self-center" style="font-size:.55rem;">Nueva</span>
             </a>
-            <form method="POST" action="${deleteUrl}" class="ms-1 flex-shrink-0"
-                  onsubmit="return confirm('¿Eliminar esta notificación?');">
+            <form method="POST" action="${deleteUrl}" class="ms-1 flex-shrink-0 notificacion-eliminar-form">
                 <input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">
-                <button type="submit" class="btn btn-sm btn-link text-muted p-0" title="Eliminar notificación" aria-label="Eliminar notificación">
+                <button type="button" class="btn btn-sm btn-link text-muted p-0 notificacion-eliminar-btn" title="Eliminar notificación" aria-label="Eliminar notificación">
                     <i class="bi bi-x-lg"></i>
                 </button>
             </form>`;

--- a/static/js/notificaciones_ws.js
+++ b/static/js/notificaciones_ws.js
@@ -1,10 +1,10 @@
 function getCookie(name) {
     if (!document.cookie) return '';
     const cookies = document.cookie.split(';');
-    for (let i = 0; i < cookies.length; i++) {
-        const cookie = cookies[i].trim();
-        if (cookie.startsWith(name + '=')) {
-            return decodeURIComponent(cookie.substring(name.length + 1));
+    for (const cookie of cookies) {
+        const c = cookie.trim();
+        if (c.startsWith(name + '=')) {
+            return decodeURIComponent(c.substring(name.length + 1));
         }
     }
     return '';

--- a/templates/ecas/puntoECA-layout.html
+++ b/templates/ecas/puntoECA-layout.html
@@ -109,10 +109,9 @@
                     <span class="badge rounded-pill bg-success align-self-center" style="font-size:.55rem;">Nueva</span>
                     {% endif %}
                   </a>
-                  <form method="POST" action="{% url 'publicacion:eliminar_notificacion' notif.id %}" class="ms-1 flex-shrink-0"
-                        onsubmit="return confirm('¿Eliminar esta notificación?');">
+                  <form method="POST" action="{% url 'publicacion:eliminar_notificacion' notif.id %}" class="ms-1 flex-shrink-0 notificacion-eliminar-form">
                     {% csrf_token %}
-                    <button type="submit" class="btn btn-sm btn-link text-muted p-0" title="Eliminar notificación" aria-label="Eliminar notificación">
+                    <button type="button" class="btn btn-sm btn-link text-muted p-0 notificacion-eliminar-btn" title="Eliminar notificación" aria-label="Eliminar notificación">
                       <i class="bi bi-x-lg"></i>
                     </button>
                   </form>
@@ -162,6 +161,32 @@
       evento: 'bi-calendar-event-fill',
       mensaje: 'bi-chat-dots-fill'
     });
+    </script>
+    <script>
+    var menuGestor = document.querySelector('[aria-labelledby="notificacionesDropdownGestor"]');
+    if (menuGestor) {
+      menuGestor.addEventListener('click', function(e) {
+        var btn = e.target.closest('.notificacion-eliminar-btn');
+        if (!btn) return;
+        e.preventDefault();
+        e.stopPropagation();
+        var form = btn.closest('.notificacion-eliminar-form');
+        Swal.fire({
+          title: '¿Eliminar esta notificación?',
+          text: 'Esta acción no se puede deshacer.',
+          icon: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#198754',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Sí, eliminar',
+          cancelButtonText: 'Cancelar'
+        }).then(function(result) {
+          if (result.isConfirmed) {
+            form.submit();
+          }
+        });
+      });
+    }
     </script>
 
   </body>

--- a/templates/ecas/puntoECA-layout.html
+++ b/templates/ecas/puntoECA-layout.html
@@ -162,32 +162,7 @@
       mensaje: 'bi-chat-dots-fill'
     });
     </script>
-    <script>
-    var menuGestor = document.querySelector('[aria-labelledby="notificacionesDropdownGestor"]');
-    if (menuGestor) {
-      menuGestor.addEventListener('click', function(e) {
-        var btn = e.target.closest('.notificacion-eliminar-btn');
-        if (!btn) return;
-        e.preventDefault();
-        e.stopPropagation();
-        var form = btn.closest('.notificacion-eliminar-form');
-        Swal.fire({
-          title: '¿Eliminar esta notificación?',
-          text: 'Esta acción no se puede deshacer.',
-          icon: 'warning',
-          showCancelButton: true,
-          confirmButtonColor: '#198754',
-          cancelButtonColor: '#6c757d',
-          confirmButtonText: 'Sí, eliminar',
-          cancelButtonText: 'Cancelar'
-        }).then(function(result) {
-          if (result.isConfirmed) {
-            form.submit();
-          }
-        });
-      });
-    }
-    </script>
+    <script>initNotificacionEliminar('notificacionesDropdownGestor');</script>
 
   </body>
 </html>

--- a/templates/users/perfil_ciudadano.html
+++ b/templates/users/perfil_ciudadano.html
@@ -162,10 +162,9 @@
                                                 <span class="badge rounded-pill bg-success align-self-center" style="font-size:.55rem;">Nueva</span>
                                                 {% endif %}
                                             </a>
-                                            <form method="POST" action="{% url 'publicacion:eliminar_notificacion' notificacion.id %}" class="ms-1 flex-shrink-0"
-                                                  onsubmit="return confirm('¿Eliminar esta notificación?');">
+                                            <form method="POST" action="{% url 'publicacion:eliminar_notificacion' notificacion.id %}" class="ms-1 flex-shrink-0 notificacion-eliminar-form">
                                                 {% csrf_token %}
-                                                <button type="submit" class="btn btn-sm btn-link text-muted p-0 notificacion-eliminar-btn" title="Eliminar notificación" aria-label="Eliminar notificación">
+                                                <button type="button" class="btn btn-sm btn-link text-muted p-0 notificacion-eliminar-btn" title="Eliminar notificación" aria-label="Eliminar notificación">
                                                     <i class="bi bi-x-lg"></i>
                                                 </button>
                                             </form>
@@ -1453,6 +1452,32 @@
 <script src="{% static 'js/notificaciones_ws.js' %}"></script>
 <script>
 initNotificacionesWS('notificacionesDropdown', { mensaje: 'bi-chat-dots-fill' }, 'bi-file-earmark-text');
+</script>
+<script>
+var menuCiudadano = document.querySelector('[aria-labelledby="notificacionesDropdown"]');
+if (menuCiudadano) {
+  menuCiudadano.addEventListener('click', function(e) {
+    var btn = e.target.closest('.notificacion-eliminar-btn');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    var form = btn.closest('.notificacion-eliminar-form');
+    Swal.fire({
+      title: '¿Eliminar esta notificación?',
+      text: 'Esta acción no se puede deshacer.',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#198754',
+      cancelButtonColor: '#6c757d',
+      confirmButtonText: 'Sí, eliminar',
+      cancelButtonText: 'Cancelar'
+    }).then(function(result) {
+      if (result.isConfirmed) {
+        form.submit();
+      }
+    });
+  });
+}
 </script>
 </body>
 </html>

--- a/templates/users/perfil_ciudadano.html
+++ b/templates/users/perfil_ciudadano.html
@@ -1453,31 +1453,6 @@
 <script>
 initNotificacionesWS('notificacionesDropdown', { mensaje: 'bi-chat-dots-fill' }, 'bi-file-earmark-text');
 </script>
-<script>
-var menuCiudadano = document.querySelector('[aria-labelledby="notificacionesDropdown"]');
-if (menuCiudadano) {
-  menuCiudadano.addEventListener('click', function(e) {
-    var btn = e.target.closest('.notificacion-eliminar-btn');
-    if (!btn) return;
-    e.preventDefault();
-    e.stopPropagation();
-    var form = btn.closest('.notificacion-eliminar-form');
-    Swal.fire({
-      title: '¿Eliminar esta notificación?',
-      text: 'Esta acción no se puede deshacer.',
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonColor: '#198754',
-      cancelButtonColor: '#6c757d',
-      confirmButtonText: 'Sí, eliminar',
-      cancelButtonText: 'Cancelar'
-    }).then(function(result) {
-      if (result.isConfirmed) {
-        form.submit();
-      }
-    });
-  });
-}
-</script>
+<script>initNotificacionEliminar('notificacionesDropdown');</script>
 </body>
 </html>


### PR DESCRIPTION
## Problema
Al intentar borrar notificaciones (tanto en el panel del Gestor ECA como en el perfil del Ciudadano), la página se recargaba pero las notificaciones no se eliminaban.

## Causas identificadas y corregidas

1. **Vista sin `@require_POST`** — Un GET accidental a la URL de eliminación solo hacía redirect sin borrar. Ahora `@require_POST` rechaza GET con 405.

2. **Notificaciones de eventos recreadas al recargar** — `_check_upcoming_event_notifications` usaba `get_or_create` en cada carga del dashboard. Al borrar una notificación de evento, el redirect la recreaba inmediatamente. **Fix:** se guarda el `evento_instancia_id` en sesión al eliminar, y `_check_upcoming_event_notifications` omite esos IDs.

3. **Notificaciones WebSocket sin botón de eliminar** — `notificaciones_ws.js` insertaba items dinámicos sin el formulario de borrado. Ahora incluye el form con CSRF token.

4. **`confirm()` nativo reemplazado por SweetAlert2** — La confirmación de eliminación ahora usa `Swal.fire()` con delegación de eventos, cubriendo tanto notificaciones server-rendered como las dinámicas del WebSocket.

## Cambios
- `apps/publicaciones/views.py` — `@require_POST` + guardado de IDs de eventos en sesión
- `apps/ecas/views.py` — filtro de eventos eliminados en `_check_upcoming_event_notifications`
- `static/js/notificaciones_ws.js` — botón X con CSRF token en items dinámicos
- `templates/ecas/puntoECA-layout.html` — SweetAlert2 + delegación de eventos
- `templates/users/perfil_ciudadano.html` — SweetAlert2 + delegación de eventos
- `apps/publicaciones/tests.py` — 7 tests nuevos (todos pasan)

## Tests
```
python manage.py test apps.publicaciones.tests.EliminarNotificacionTests -v2 --keepdb
```
7 tests OK:
- POST elimina notificación propia (ciudadano y gestor)
- GET devuelve 405
- No elimina notificación ajena (404)
- Requiere autenticación
- Sesión guarda evento_instancia_id al eliminar
- No recrea eventos eliminados