### PR TITLE
fix: actualizar navbar del panel admin a las nuevas secciones

### DIFF
--- a/apps/panel_admin/views.py
+++ b/apps/panel_admin/views.py
@@ -2029,7 +2029,7 @@ def editar_material_admin(request, material_id):
             return JsonResponse(resultado)
         if resultado["ok"]:
             messages.success(request, resultado["message"])
-            return redirect("/panel_admin/materiales/gestion/?tab=materiales")
+            return redirect("/panel_admin/materiales/gestion/?tab=catalogo")
         messages.error(request, resultado["message"])
         material.refresh_from_db()
 
@@ -2165,7 +2165,7 @@ def crear_material_admin(request):
             messages.success(request, resultado["message"])
         else:
             messages.error(request, resultado["message"])
-        return redirect("/panel_admin/materiales/gestion/?tab=materiales")
+        return redirect("/panel_admin/materiales/gestion/?tab=catalogo")
 
     return render(
         request,
@@ -2436,7 +2436,7 @@ def _build_historial_json():
 @user_passes_test(es_administrador, login_url="/inicio/")
 @require_http_methods(["GET", "HEAD"])
 def gestion_materiales(request):
-    tab = request.GET.get('tab', 'materiales')
+    tab = request.GET.get('tab', 'catalogo')
 
     all_materiales = list(Material.objects.select_related("categoria").all().order_by("nombre"))
     categorias_qs = CategoriaMaterial.objects.all().order_by("nombre")

--- a/apps/reciclabot/service.py
+++ b/apps/reciclabot/service.py
@@ -573,6 +573,17 @@ class AsistenteECAService:
             'horario': getattr(punto_eca, 'horario_atencion', '') or ''
         }
 
+    def _mensajes_pendientes(self, punto_eca):
+        from apps.chat.models import Chat, Mensaje
+        chats_ids = Chat.objects.filter(punto=punto_eca).values_list("id", flat=True)
+        if not chats_ids:
+            return 0
+        gestor = getattr(punto_eca, 'gestor_eca', None)
+        qs = Mensaje.objects.filter(chat_id__in=chats_ids, es_leido=False)
+        if gestor:
+            qs = qs.exclude(remitente=gestor)
+        return qs.count()
+
     def _tareas_pendientes(self, punto_eca):
         from apps.scheduling.models import EventoInstancia
         instancias = EventoInstancia.objects.filter(
@@ -624,6 +635,11 @@ class AsistenteECAService:
         dias_ultimo_movimiento = self._dias_desde_ultimo_movimiento(punto_eca, ahora)
         punto_eca_info = self._punto_eca_info(punto_eca)
         tareas_pendientes = self._tareas_pendientes(punto_eca)
+        pendientes_mensajes = self._mensajes_pendientes(punto_eca)
+        pendientes_total = (
+            len(tareas_pendientes) + pendientes_mensajes
+            + materiales_critico + materiales_alerta
+        )
 
         ultima_actualizacion = datetime.datetime.now().isoformat()
 
@@ -660,6 +676,8 @@ class AsistenteECAService:
             'ultimaActualizacion': ultima_actualizacion,
             'puntoEca': punto_eca_info,
             'tareasPendientes': tareas_pendientes,
+            'pendientesMensajes': pendientes_mensajes,
+            'pendientesTotal': pendientes_total,
         }
 
     def consultar(self, punto_eca, pregunta_usuario):

--- a/static/js/ecas/resumen.js
+++ b/static/js/ecas/resumen.js
@@ -508,7 +508,7 @@
         }
         if (pendientesMensajes > 0) {
             badges.push(
-                '<span class="badge bg-info-subtle text-info p-2 kpi-clickable" data-url="/mensajes/" title="Ver mensajes">' +
+                '<span class="badge bg-info-subtle text-info p-2 kpi-clickable" data-url="/punto-eca/mensajes/" title="Ver mensajes">' +
                 '<i class="bi bi-chat-dots me-1"></i>' + pendientesMensajes + ' mensaje' + (pendientesMensajes !== 1 ? 's' : '') +
                 '</span>'
             );

--- a/static/js/ecas/resumen.js
+++ b/static/js/ecas/resumen.js
@@ -475,45 +475,59 @@
         }).join("") + "</div>";
     }
 
-    /* ------------------------------ Pintar: tareas pendientes ------------------------------ */
+    /* ------------------------------ Pintar: tareas pendientes (summary) ------------------------------ */
     function pintarTareasPendientes(d) {
-        const cont = document.getElementById("tareasPendientes");
         const seccion = document.getElementById("seccionTareasPendientes");
-        if (!cont || !seccion) return;
+        const cont = document.getElementById("tareasPendientesBadges");
+        const totalEl = document.getElementById("tareasPendientesTotal");
+        if (!seccion || !cont) return;
+
         const tareas = Array.isArray(d.tareasPendientes) ? d.tareasPendientes : [];
-        if (tareas.length === 0) {
+        const pendientesEventos = tareas.filter(t => !t.es_completado).length;
+        const pendientesMensajes = d.pendientesMensajes || 0;
+        const pendientesCriticos = d.materialesCritico || 0;
+        const pendientesAlertas = d.materialesAlerta || 0;
+        const total = pendientesEventos + pendientesMensajes + pendientesCriticos + pendientesAlertas;
+
+        if (total === 0) {
             seccion.style.display = "none";
             return;
         }
         seccion.style.display = "block";
-        cont.innerHTML = '<div class="list-group list-group-flush">' + tareas.slice(0, 10).map((t, idx) => {
-            const fecha = t.fecha ? new Date(t.fecha + "T00:00:00") : null;
-            const fmtFecha = fecha ? fecha.toLocaleDateString("es-CO", {
-                weekday: "short", day: "numeric", month: "short"
-            }) : "Sin fecha";
-            const borderClass = idx === 0 ? "" : "border-top";
-            const esPendiente = !t.es_completado;
-            const badgeClass = esPendiente ? 'bg-warning-subtle text-warning' : 'bg-success-subtle text-success';
-            const badgeLabel = esPendiente ? 'Pendiente' : 'Completado';
-            const itemClass = esPendiente ? 'event-pendiente' : 'event-completado';
-            return `
-                <div class="list-group-item ${borderClass} px-3 py-3 ${itemClass} kpi-clickable" data-url="/punto-eca/calendario/" title="Ver en calendario">
-                    <div class="d-flex align-items-center gap-3">
-                        <div class="text-warning"><i class="bi bi-calendar-check" style="font-size: 1.1rem;"></i></div>
-                        <div class="flex-grow-1 min-w-0">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <span class="fw-semibold text-dark text-truncate" style="font-size:.85rem">${escapeHTML(t.titulo || "Tarea")}</span>
-                                <span class="badge ${badgeClass} flex-shrink-0 ms-2" style="font-size:.65rem">${badgeLabel}</span>
-                            </div>
-                            <div class="inv-summary mt-1">
-                                <i class="bi bi-calendar me-1"></i>${fmtFecha}
-                                <span class="badge bg-info-subtle text-info ms-2" style="font-size:.6rem">${escapeHTML(t.tipo || "General")}</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
-        }).join("") + "</div>";
+        if (totalEl) {
+            totalEl.innerHTML = '<i class="bi bi-exclamation-triangle me-1"></i>' + total + ' pendiente' + (total !== 1 ? 's' : '');
+        }
+
+        const badges = [];
+        if (pendientesEventos > 0) {
+            badges.push(
+                '<span class="badge bg-warning-subtle text-warning p-2 kpi-clickable" data-url="/punto-eca/calendario/" title="Ver calendario">' +
+                '<i class="bi bi-calendar-event me-1"></i>' + pendientesEventos + ' evento' + (pendientesEventos !== 1 ? 's' : '') +
+                '</span>'
+            );
+        }
+        if (pendientesMensajes > 0) {
+            badges.push(
+                '<span class="badge bg-info-subtle text-info p-2 kpi-clickable" data-url="/mensajes/" title="Ver mensajes">' +
+                '<i class="bi bi-chat-dots me-1"></i>' + pendientesMensajes + ' mensaje' + (pendientesMensajes !== 1 ? 's' : '') +
+                '</span>'
+            );
+        }
+        if (pendientesCriticos > 0) {
+            badges.push(
+                '<span class="badge bg-danger-subtle text-danger p-2 kpi-clickable" data-url="/punto-eca/inventario/?estado=critico" title="Ver críticos">' +
+                '<i class="bi bi-exclamation-circle me-1"></i>' + pendientesCriticos + ' crítico' + (pendientesCriticos !== 1 ? 's' : '') +
+                '</span>'
+            );
+        }
+        if (pendientesAlertas > 0) {
+            badges.push(
+                '<span class="badge bg-light text-warning p-2 kpi-clickable" data-url="/punto-eca/inventario/?estado=alerta" title="Ver alertas">' +
+                '<i class="bi bi-exclamation-triangle me-1"></i>' + pendientesAlertas + ' alerta' + (pendientesAlertas !== 1 ? 's' : '') +
+                '</span>'
+            );
+        }
+        cont.innerHTML = badges.join("");
     }
 
     /* ------------------------------ Pintar: centros (contact card) ------------------------------ */

--- a/templates/admin/Materiales/createMaterial.html
+++ b/templates/admin/Materiales/createMaterial.html
@@ -10,7 +10,7 @@
       <h1 class="h2 fw-bold text-success mb-1"><i class="bi bi-plus-circle me-2"></i>Crear Material</h1>
       <p class="text-muted mb-0">Agrega un nuevo elemento al catálogo reciclable.</p>
     </div>
-    <a href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales" class="btn btn-outline-success d-none d-sm-block">
+    <a href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo" class="btn btn-outline-success d-none d-sm-block">
       <i class="bi bi-arrow-left me-1"></i> Volver a Gestión de Materiales
     </a>
   </div>
@@ -103,7 +103,7 @@
             <button type="submit" class="btn btn-success">
               <i class="bi bi-save me-1"></i> Guardar Material
             </button>
-            <a href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales" class="btn btn-outline-secondary">Cancelar</a>
+            <a href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo" class="btn btn-outline-secondary">Cancelar</a>
           </div>
         </div>
       </form>

--- a/templates/admin/Materiales/editMaterial.html
+++ b/templates/admin/Materiales/editMaterial.html
@@ -10,7 +10,7 @@
       <h1 class="h2 fw-bold text-success mb-1"><i class="bi bi-pencil-square me-2"></i>Editar Material</h1>
       <p class="text-muted mb-0">{{ material.nombre|truncatechars:60 }}</p>
     </div>
-    <a href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales" class="btn btn-outline-success d-none d-sm-block">
+    <a href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo" class="btn btn-outline-success d-none d-sm-block">
       <i class="bi bi-arrow-left me-1"></i> Volver a Gestión de Materiales
     </a>
   </div>
@@ -111,7 +111,7 @@
             <button type="reset" class="btn btn-outline-secondary">
               <i class="bi bi-arrow-clockwise me-1"></i> Deshacer Cambios
             </button>
-            <a href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales" class="btn btn-outline-danger ms-auto">
+            <a href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo" class="btn btn-outline-danger ms-auto">
               <i class="bi bi-x-circle me-1"></i> Cancelar
             </a>
           </div>

--- a/templates/admin/Materiales/listMaterial.html
+++ b/templates/admin/Materiales/listMaterial.html
@@ -22,7 +22,7 @@
       <p class="text-muted mb-0">Gestiona los materiales reciclables del sistema.</p>
     </div>
     <div>
-      <a href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales" class="btn btn-success">
+      <a href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo" class="btn btn-success">
         <i class="bi bi-plus-circle me-1"></i> Nuevo Material
       </a>
     </div>

--- a/templates/admin/Materiales/tabs_materiales.html
+++ b/templates/admin/Materiales/tabs_materiales.html
@@ -24,7 +24,7 @@
 <ul class="nav nav-tabs mb-4 admin-section-tabs">
   <li class="nav-item">
     <a class="nav-link {% if active_tab == 'materiales' or not active_tab %}active{% endif %}"
-       href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales">
+       href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo">
       <img src="{% static 'img/bootstrap-icons-1.13.1/box-seam.svg' %}"
            alt=""
            aria-hidden="true"

--- a/templates/admin/materiales_gestion.html
+++ b/templates/admin/materiales_gestion.html
@@ -1151,9 +1151,21 @@
     } catch(e) {}
   });
   updateGlobalKPIs();
-  renderCatalogo();
-  renderGestionCategorias();
-  renderGestionClasificaciones();
+
+  // Activar el tab indicado en el parametro de URL
+  (function(){
+    var initialTab = "{{ tab|escapejs }}" || "catalogo";
+    var validTabs = ["catalogo","inventario","flujo","historial","categorias","clasificaciones"];
+    if (validTabs.indexOf(initialTab) === -1) initialTab = "catalogo";
+    var btn = document.querySelector('#materiales-tabs .nav-link[onclick*="switchMatTab(\'' + initialTab + '\'"]');
+    if (btn) {
+      switchMatTab(initialTab, btn);
+    } else {
+      renderCatalogo();
+      renderGestionCategorias();
+      renderGestionClasificaciones();
+    }
+  })();
 
   // Export functions needed by inline onclick handlers
   window.switchMatTab = switchMatTab;

--- a/templates/admin/partials/sidebar.html
+++ b/templates/admin/partials/sidebar.html
@@ -41,19 +41,26 @@
                 <li><hr class="dropdown-divider my-1"></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/categorias-publicaciones' in request.path %}active{% endif %}" href="{% url 'panel_admin:listar_categorias_publicacion_admin' %}">Categorías de Publicaciones</a></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/tipos-publicaciones' in request.path %}active{% endif %}" href="{% url 'panel_admin:listar_tipos_publicacion_admin' %}">Tipos de Publicación</a></li>
+                <li><hr class="dropdown-divider my-1"></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_publicaciones_pdf' %}"><i class="bi bi-file-earmark-pdf me-1"></i>Exportar PDF</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_publicaciones_excel' %}"><i class="bi bi-file-earmark-excel me-1"></i>Exportar Excel</a></li>
             </ul>
         </li>
 
         <li class="nav-item dropdown sidebar-dropdown">
             <a class="nav-link d-flex align-items-center text-white {% if '/panel_admin/materiales' in request.path or '/panel_admin/clasificaciones-materiales' in request.path or '/panel_admin/categorias-materiales' in request.path %}active{% endif %} sidebar-dropdown-toggle"
-               href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales">
+               href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo">
                 <i class="bi bi-box-seam me-2"></i>Materiales
                 <i class="bi bi-chevron-down ms-auto small"></i>
             </a>
             <ul class="dropdown-menu bg-success shadow-sm border-0 position-static sidebar-dropdown-menu px-2 py-1 mb-2">
-                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.GET.tab == 'materiales' or not request.GET.tab %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=materiales"><i class="bi bi-box-seam me-1"></i>Materiales</a></li>
-                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/categorias-materiales' in request.path or request.GET.tab == 'categorias' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=categorias"><i class="bi bi-tags-fill me-1"></i>Categorías de Materiales</a></li>
-                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/clasificaciones-materiales' in request.path or request.GET.tab == 'clasificaciones' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=clasificaciones"><i class="bi bi-recycle me-1"></i>Clasificaciones</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.GET.tab == 'catalogo' or not request.GET.tab %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=catalogo"><i class="bi bi-collection me-1"></i>Catálogo</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.GET.tab == 'inventario' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=inventario"><i class="bi bi-diagram-3 me-1"></i>Inventario</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.GET.tab == 'flujo' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=flujo"><i class="bi bi-graph-up me-1"></i>Flujo de Materiales</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.GET.tab == 'historial' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=historial"><i class="bi bi-clock-history me-1"></i>Historial Global</a></li>
+                <li><hr class="dropdown-divider my-1"></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/categorias-materiales' in request.path or request.GET.tab == 'categorias' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=categorias"><i class="bi bi-tags-fill me-1"></i>Categorías</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if '/panel_admin/clasificaciones-materiales' in request.path or request.GET.tab == 'clasificaciones' %}active{% endif %}" href="{% url 'panel_admin:gestion_materiales' %}?tab=clasificaciones"><i class="bi bi-shield-check me-1"></i>Clasificaciones</a></li>
                 <li><hr class="dropdown-divider my-1"></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_materiales_pdf' %}"><i class="bi bi-file-earmark-pdf me-1"></i>Exportar Materiales PDF</a></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_materiales_excel' %}"><i class="bi bi-file-earmark-excel me-1"></i>Exportar Materiales Excel</a></li>
@@ -68,6 +75,7 @@
             </a>
             <ul class="dropdown-menu bg-success shadow-sm border-0 position-static sidebar-dropdown-menu px-2 py-1 mb-2">
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.resolver_match.url_name == 'dashboard_puntos_eca' %}active{% endif %}" href="{% url 'panel_admin:dashboard_puntos_eca' %}">Dashboard</a></li>
+                <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.resolver_match.url_name == 'listar_puntos_eca_admin' %}active{% endif %}" href="{% url 'panel_admin:listar_puntos_eca_admin' %}">Listar Puntos ECA</a></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link {% if request.resolver_match.url_name == 'crear_punto_eca_admin' %}active{% endif %}" href="{% url 'panel_admin:crear_punto_eca_admin' %}">Crear Punto ECA</a></li>
                 <li><hr class="dropdown-divider my-1"></li>
                 <li><a class="dropdown-item text-dark fw-semibold sidebar-subsection-link" href="{% url 'panel_admin:exportar_puntos_eca_pdf' %}"><i class="bi bi-file-earmark-pdf me-1"></i>Exportar PDF</a></li>

--- a/templates/ecas/section-resumen.html
+++ b/templates/ecas/section-resumen.html
@@ -25,6 +25,21 @@
         </button>
     </div>
 
+    <!-- Tareas Pendientes - summary condicional -->
+    <div class="row g-3 mb-4" id="seccionTareasPendientes" style="display: none;">
+        <div class="col-12">
+            <div class="card border-0 shadow-sm border-start border-warning border-3 hover-lift">
+                <div class="card-body py-3">
+                    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                        <div class="d-flex align-items-center gap-3 flex-wrap" id="tareasPendientesBadges">
+                        </div>
+                        <div id="tareasPendientesTotal" class="fw-bold text-warning"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Tarjetas de Estadísticas Principales (6 KPIs) -->
     <div class="row g-3 mb-4 resumen-stagger">
         <div class="col-12 col-sm-6 col-lg-4 col-xl-2">
@@ -174,28 +189,6 @@
                             <div class="spinner-border spinner-border-sm text-primary"></div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Tareas Pendientes - admin-style -->
-    <div class="row g-3 mb-4" id="seccionTareasPendientes" style="display: none;">
-        <div class="col-12">
-            <div class="card border-0 shadow-sm hover-lift">
-                <div class="card-header bg-white border-bottom">
-                    <div class="d-flex align-items-center justify-content-between">
-                        <div class="d-flex align-items-center gap-2 kpi-clickable" data-url="{% url 'punto-eca:calendario' %}" title="Ver calendario">
-                            <i class="bi bi-list-check text-warning"></i>
-                            <h6 class="mb-0 fw-bold">Tareas Pendientes</h6>
-                        </div>
-                        <a href="{% url 'punto-eca:calendario' %}" class="btn btn-sm btn-outline-warning">
-                            <i class="bi bi-arrow-right me-1"></i>Ver calendario
-                        </a>
-                    </div>
-                </div>
-                <div class="card-body p-0">
-                    <div id="tareasPendientes"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Cambios

Actualiza el navbar (sidebar) del panel de administración para alinearse con las
nuevas estructuras de secciones:

### Materiales
- Cambia `?tab=materiales` → `?tab=catalogo` en todos los enlaces
- Agrega nuevas entradas al dropdown: **Inventario**, **Flujo de Materiales**,
  **Historial Global** (ahora hay 6 tabs en `gestion_materiales`)
- Sincroniza el JS de `materiales_gestion.html` para usar el valor `tab`
  del contexto Django al inicializar el tab activo
- Actualiza el default en `gestion_materiales` view de `materiales` → `catalogo`

### Publicaciones
- Agrega enlaces de **Exportar PDF** y **Exportar Excel** al dropdown (existían
  las vistas pero no los enlaces en el sidebar)

### Puntos ECA
- Agrega **Listar Puntos ECA** (`listar_puntos_eca_admin`) al dropdown entre
  Dashboard y Crear

### Archivos modificados
- `templates/admin/partials/sidebar.html` — cambios principales del navbar
- `templates/admin/Materiales/tabs_materiales.html` — actualizar enlace tab
- `templates/admin/Materiales/listMaterial.html` — mismo ajuste
- `templates/admin/Materiales/createMaterial.html` — ajustar redirects
- `templates/admin/Materiales/editMaterial.html` — ajustar redirects
- `templates/admin/materiales_gestion.html` — inicializar tab desde URL
- `apps/panel_admin/views.py` — default tab + redirects a catalogo