### PR TITLE
fix: deduplicar datos antes de crear UniqueConstraints

### DIFF
--- a/apps/inventory/migrations/0014_categoriamaterial_uq_categoria_material_nombre_and_more.py
+++ b/apps/inventory/migrations/0014_categoriamaterial_uq_categoria_material_nombre_and_more.py
@@ -3,6 +3,36 @@
 from django.db import migrations, models
 
 
+def deduplicar_materiales(apps, schema_editor):
+    Material = apps.get_model("inventory", "Material")
+    duplicados = (
+        Material.objects.values("nombre")
+        .annotate(total=models.Count("id"))
+        .filter(total__gt=1)
+    )
+    for entrada in duplicados:
+        nombre = entrada["nombre"]
+        registros = list(Material.objects.filter(nombre=nombre).order_by("fecha_creacion"))
+        for idx, dup in enumerate(registros[1:], start=2):
+            dup.nombre = f"{nombre} (dup {idx})"
+            dup.save(update_fields=["nombre"])
+
+
+def deduplicar_categorias_material(apps, schema_editor):
+    CategoriaMaterial = apps.get_model("inventory", "CategoriaMaterial")
+    duplicados = (
+        CategoriaMaterial.objects.values("nombre")
+        .annotate(total=models.Count("id"))
+        .filter(total__gt=1)
+    )
+    for entrada in duplicados:
+        nombre = entrada["nombre"]
+        registros = list(CategoriaMaterial.objects.filter(nombre=nombre).order_by("fecha_creacion"))
+        for idx, dup in enumerate(registros[1:], start=2):
+            dup.nombre = f"{nombre} (dup {idx})"
+            dup.save(update_fields=["nombre"])
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -10,6 +40,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(deduplicar_materiales, migrations.RunPython.noop),
+        migrations.RunPython(deduplicar_categorias_material, migrations.RunPython.noop),
         migrations.AddConstraint(
             model_name='categoriamaterial',
             constraint=models.UniqueConstraint(fields=('nombre',), name='uq_categoria_material_nombre'),

--- a/apps/publicaciones/migrations/0019_categoriapublicacion_uq_categoria_publicacion_nombre_tipo_and_more.py
+++ b/apps/publicaciones/migrations/0019_categoriapublicacion_uq_categoria_publicacion_nombre_tipo_and_more.py
@@ -4,6 +4,54 @@ from django.conf import settings
 from django.db import migrations, models
 
 
+def deduplicar_tipo_publicacion(apps, schema_editor):
+    TipoPublicacion = apps.get_model("publicaciones", "TipoPublicacion")
+    duplicados = (
+        TipoPublicacion.objects.values("nombre")
+        .annotate(total=models.Count("id"))
+        .filter(total__gt=1)
+    )
+    for entrada in duplicados:
+        nombre = entrada["nombre"]
+        registros = list(TipoPublicacion.objects.filter(nombre=nombre).order_by("fecha_creacion"))
+        for idx, dup in enumerate(registros[1:], start=2):
+            dup.nombre = f"{nombre} (dup {idx})"
+            dup.save(update_fields=["nombre"])
+
+
+def deduplicar_categoria_publicacion(apps, schema_editor):
+    CategoriaPublicacion = apps.get_model("publicaciones", "CategoriaPublicacion")
+    duplicados = (
+        CategoriaPublicacion.objects.values("nombre", "tipo")
+        .annotate(total=models.Count("id"))
+        .filter(total__gt=1)
+    )
+    for entrada in duplicados:
+        nombre = entrada["nombre"]
+        tipo = entrada["tipo"]
+        registros = list(
+            CategoriaPublicacion.objects.filter(nombre=nombre, tipo=tipo).order_by("fecha_creacion")
+        )
+        for idx, dup in enumerate(registros[1:], start=2):
+            dup.nombre = f"{nombre} (dup {idx})"
+            dup.save(update_fields=["nombre"])
+
+
+def deduplicar_publicacion(apps, schema_editor):
+    Publicacion = apps.get_model("publicaciones", "Publicacion")
+    duplicados = (
+        Publicacion.objects.values("titulo")
+        .annotate(total=models.Count("id"))
+        .filter(total__gt=1)
+    )
+    for entrada in duplicados:
+        titulo = entrada["titulo"]
+        registros = list(Publicacion.objects.filter(titulo=titulo).order_by("fecha_creacion"))
+        for idx, dup in enumerate(registros[1:], start=2):
+            dup.titulo = f"{titulo} (dup {idx})"
+            dup.save(update_fields=["titulo"])
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,6 +60,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(deduplicar_tipo_publicacion, migrations.RunPython.noop),
+        migrations.RunPython(deduplicar_categoria_publicacion, migrations.RunPython.noop),
+        migrations.RunPython(deduplicar_publicacion, migrations.RunPython.noop),
         migrations.AddConstraint(
             model_name='categoriapublicacion',
             constraint=models.UniqueConstraint(fields=('nombre', 'tipo'), name='uq_categoria_publicacion_nombre_tipo'),


### PR DESCRIPTION
## Descripción

Fixes the deploy failure caused by PR #194. The migrations failed in production because the database already contained duplicate records (e.g. Material 'Cartón' appeared twice).

## Cambios

Ambas migraciones ahora ejecutan operaciones `RunPython` de deduplicación **antes** de crear las `UniqueConstraint`:

### `inventory/0014`
- `deduplicar_materiales`: renombra duplicados en `Material` como `"nombre (dup N)"`
- `deduplicar_categorias_material`: renombra duplicados en `CategoriaMaterial`

### `publicaciones/0019`
- `deduplicar_tipo_publicacion`: renombra duplicados en `TipoPublicacion`
- `deduplicar_categoria_publicacion`: renombra duplicados de nombre+tipo en `CategoriaPublicacion`
- `deduplicar_publicacion`: renombra duplicados en `Publicacion`

Siempre se conserva el registro más antiguo (por `fecha_creacion`) y los demás se renombran.